### PR TITLE
auth module

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "class-validator": "^0.14.0",
     "env-cmd": "^10.1.0",
     "express-basic-auth": "^1.2.1",
+    "fast-copy": "^3.0.2",
     "joi": "^17.9.2",
     "ms": "^2.1.3",
     "nest-winston": "^1.9.3",
@@ -52,7 +53,6 @@
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
     "typeorm": "^0.3.17",
-    "uuid": "^11.1.0",
     "winston": "^3.10.0"
   },
   "devDependencies": {

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,0 +1,51 @@
+import { Module } from "@nestjs/common";
+import { PassportModule } from "@nestjs/passport";
+import { KakaoStrategy } from "./strategies";
+import { JwtModule } from "@nestjs/jwt";
+import {
+  ConfigurationServiceInjector,
+  TokenConfigService,
+} from "src/configuration";
+import {
+  KakaoLoginController,
+  KaKaoLoginCommandHandler,
+  LogoutController,
+  LogoutCommandHandler,
+  WithdrawalController,
+  WithdrawalCommandHandler,
+  TokenReissueController,
+  TokenReissueCommandHandler,
+} from "./commands";
+import { CqrsModule } from "@nestjs/cqrs";
+
+const command = [
+  KaKaoLoginCommandHandler,
+  LogoutCommandHandler,
+  WithdrawalCommandHandler,
+  TokenReissueCommandHandler,
+];
+const controller = [
+  KakaoLoginController,
+  LogoutController,
+  WithdrawalController,
+  TokenReissueController,
+];
+
+@Module({
+  imports: [
+    CqrsModule,
+    PassportModule,
+    JwtModule.registerAsync({
+      useFactory: (tokenConfig: TokenConfigService) => ({
+        secret: tokenConfig.accessTokenSecret,
+        signOptions: {
+          expiresIn: tokenConfig.accessTokenExpiresIn,
+        },
+      }),
+      inject: [ConfigurationServiceInjector.TOKEN_SERVICE],
+    }),
+  ],
+  controllers: [...controller],
+  providers: [KakaoStrategy, ...command],
+})
+export class AuthModule {}

--- a/src/auth/commands/index.ts
+++ b/src/auth/commands/index.ts
@@ -1,0 +1,4 @@
+export * from "./kakao-login";
+export * from "./logout";
+export * from "./withdrawal";
+export * from "./token-reissue";

--- a/src/auth/commands/kakao-login/index.ts
+++ b/src/auth/commands/kakao-login/index.ts
@@ -1,0 +1,4 @@
+export * from "./kakao-login.controller";
+export * from "./kakao-login.handler";
+export * from "./kakao-login.command";
+export * from "./kakao-login.dto";

--- a/src/auth/commands/kakao-login/kakao-login.command.ts
+++ b/src/auth/commands/kakao-login/kakao-login.command.ts
@@ -1,0 +1,10 @@
+import { ICommand } from "@nestjs/cqrs";
+
+export class KaKaoLoginCommand implements ICommand {
+  constructor(
+    public readonly externalId: string,
+    public readonly name: string,
+    public readonly profile: string,
+    public readonly email: string
+  ) {}
+}

--- a/src/auth/commands/kakao-login/kakao-login.controller.ts
+++ b/src/auth/commands/kakao-login/kakao-login.controller.ts
@@ -1,0 +1,32 @@
+import { Controller, Get, UseGuards } from "@nestjs/common";
+import { ApiOkResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
+import { CommandBus } from "@nestjs/cqrs";
+import { KakaoAuthGuard } from "../../guards";
+import { Social } from "../../decorators";
+import { SocialPayload } from "../../interfaces";
+import { KaKaoLoginCommand } from "./kakao-login.command";
+import { KaKaoLoginResponseDto } from "./kakao-login.dto";
+
+@ApiTags("Auth")
+@Controller({ path: "auth", version: "1" })
+export class KakaoLoginController {
+  constructor(private readonly commandBus: CommandBus) {}
+
+  @ApiOperation({ summary: "Kakao 소셜 로그인" })
+  @Get("kakao")
+  @UseGuards(KakaoAuthGuard)
+  @ApiOkResponse({
+    description: "Kakao 소셜 로그인 성공",
+    type: KaKaoLoginResponseDto,
+  })
+  login(@Social() user: SocialPayload) {
+    return this.commandBus.execute(
+      new KaKaoLoginCommand(
+        user.externalId,
+        user.name,
+        user.profile,
+        user.email
+      )
+    );
+  }
+}

--- a/src/auth/commands/kakao-login/kakao-login.dto.ts
+++ b/src/auth/commands/kakao-login/kakao-login.dto.ts
@@ -1,0 +1,13 @@
+export class KaKaoLoginResponseDto {
+  /**
+   * Access Token
+   * @example "AT"
+   */
+  AT: string;
+
+  /**
+   * Refresh Token
+   * @example "RT"
+   */
+  RT: string;
+}

--- a/src/auth/commands/kakao-login/kakao-login.handler.ts
+++ b/src/auth/commands/kakao-login/kakao-login.handler.ts
@@ -1,0 +1,93 @@
+import { CommandHandler, ICommandHandler } from "@nestjs/cqrs";
+import { KaKaoLoginCommand } from "./kakao-login.command";
+import { InjectEntityManager } from "@nestjs/typeorm";
+import { EntityManager } from "typeorm";
+import {
+  User as UserEntity,
+  AuthSocial as AuthSocialEntity,
+  RefreshToken as RefreshTokenEntity,
+} from "src/database";
+import { AuthSocial, RefreshToken, SocialCodeVO } from "../../domain";
+import {
+  ConfigurationServiceInjector,
+  TokenConfigService,
+} from "src/configuration";
+import { User, UserMapper } from "src/user";
+import { AuthSocialMapper, RefreshTokenMapper } from "../../mappers";
+import { JwtManagerService, UUID } from "src/common";
+import { Inject } from "@nestjs/common";
+import { randomUUID } from "crypto";
+
+@CommandHandler(KaKaoLoginCommand)
+export class KaKaoLoginCommandHandler
+  implements ICommandHandler<KaKaoLoginCommand>
+{
+  constructor(
+    @InjectEntityManager()
+    private readonly manager: EntityManager,
+    private readonly jwtManager: JwtManagerService,
+    @Inject(ConfigurationServiceInjector.TOKEN_SERVICE)
+    private readonly tokenConfig: TokenConfigService
+  ) {}
+
+  async execute(command: KaKaoLoginCommand) {
+    const { externalId, name, profile, email } = command;
+
+    const userId = await this.findOrCreateUser(
+      externalId,
+      name,
+      profile,
+      email
+    );
+    const sessionId = randomUUID();
+
+    const AT = await this.jwtManager.generateAccessToken(userId, sessionId);
+    const RT = await this.jwtManager.generateRefreshToken(userId);
+
+    await this.manager.insert(
+      RefreshTokenEntity,
+      RefreshTokenMapper.toPersistence(
+        RefreshToken.create({
+          userId: userId,
+          token: RT,
+          sessionId,
+          expiredAt: this.tokenConfig.refreshTokenExpiresIn,
+        })
+      )
+    );
+
+    return { AT, RT };
+  }
+
+  private async findOrCreateUser(
+    externalId: string,
+    name: string,
+    profile: string,
+    email: string
+  ): Promise<string> {
+    const existing = await this.manager.findOne(AuthSocialEntity, {
+      where: {
+        externalId,
+        socialCode: SocialCodeVO.KAKAO.value,
+      },
+    });
+
+    if (existing) return existing.userId;
+
+    const newUser = User.create({ name, profile, email });
+    await this.manager.insert(UserEntity, UserMapper.toPersistence(newUser));
+
+    await this.manager.insert(
+      AuthSocialEntity,
+      AuthSocialMapper.toPersistence(
+        AuthSocial.create({
+          externalId,
+          socialCode: SocialCodeVO.KAKAO,
+          userId: newUser.id.unpack(),
+        })
+      )
+    );
+
+    return newUser.id.unpack();
+  }
+}

--- a/src/auth/commands/logout/index.ts
+++ b/src/auth/commands/logout/index.ts
@@ -1,0 +1,3 @@
+export * from "./logout.command";
+export * from "./logout.controller";
+export * from "./logout.handler";

--- a/src/auth/commands/logout/logout.command.ts
+++ b/src/auth/commands/logout/logout.command.ts
@@ -1,0 +1,8 @@
+import { ICommand } from "@nestjs/cqrs";
+
+export class LogoutCommand implements ICommand {
+  constructor(
+    public readonly userId: string,
+    public readonly sessionId: string
+  ) {}
+}

--- a/src/auth/commands/logout/logout.controller.ts
+++ b/src/auth/commands/logout/logout.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Post, UseGuards } from "@nestjs/common";
+import { CommandBus } from "@nestjs/cqrs";
+import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
+import { AccessTokenGuard, SwaggerAuth, User, UserPayload } from "src/common";
+import { LogoutCommand } from "./logout.command";
+
+@ApiTags("Auth")
+@Controller({ path: "auth", version: "1" })
+export class LogoutController {
+  constructor(private readonly commandBus: CommandBus) {}
+
+  @Post("logout")
+  @UseGuards(AccessTokenGuard)
+  @ApiOperation({ summary: "로그아웃" })
+  @ApiBearerAuth(SwaggerAuth.AUTH_AT)
+  logout(@User() user: UserPayload) {
+    return this.commandBus.execute(
+      new LogoutCommand(user.userId, user.sessionId)
+    );
+  }
+}

--- a/src/auth/commands/logout/logout.handler.ts
+++ b/src/auth/commands/logout/logout.handler.ts
@@ -1,0 +1,26 @@
+import { CommandHandler, ICommandHandler } from "@nestjs/cqrs";
+import { LogoutCommand } from "./logout.command";
+import { InjectEntityManager } from "@nestjs/typeorm";
+import { EntityManager } from "typeorm";
+import { RefreshToken } from "src/database";
+
+@CommandHandler(LogoutCommand)
+export class LogoutCommandHandler implements ICommandHandler<LogoutCommand> {
+  constructor(
+    @InjectEntityManager()
+    private readonly manager: EntityManager
+  ) {}
+
+  async execute(command: LogoutCommand): Promise<void> {
+    const { userId, sessionId } = command;
+
+    const result = await this.manager.delete(RefreshToken, {
+      userId: userId,
+      sessionId: sessionId,
+    });
+
+    if (!result.affected) {
+      throw new Error("Refresh token 삭제 실패했습니다.");
+    }
+  }
+}

--- a/src/auth/commands/token-reissue/index.ts
+++ b/src/auth/commands/token-reissue/index.ts
@@ -1,0 +1,3 @@
+export * from "./token-reissue.command";
+export * from "./token-reissue.controller";
+export * from "./token-reissue.handler";

--- a/src/auth/commands/token-reissue/token-reissue.command.ts
+++ b/src/auth/commands/token-reissue/token-reissue.command.ts
@@ -1,0 +1,8 @@
+import { ICommand } from "@nestjs/cqrs";
+
+export class TokenReissueCommand implements ICommand {
+  constructor(
+    public readonly userId: string,
+    public readonly sessionId: string
+  ) {}
+}

--- a/src/auth/commands/token-reissue/token-reissue.controller.ts
+++ b/src/auth/commands/token-reissue/token-reissue.controller.ts
@@ -1,0 +1,31 @@
+import { Controller, Get, UseGuards } from "@nestjs/common";
+import { CommandBus } from "@nestjs/cqrs";
+import {
+  ApiBearerAuth,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from "@nestjs/swagger";
+import { ReissueTokenGuard } from "../../guards";
+import { SwaggerAuth, User, UserPayload } from "src/common";
+import { TokenReissueCommand } from "./token-reissue.command";
+import { TokenReissueResponseDto } from "./token-reissue.dto";
+
+@ApiTags("Auth")
+@Controller({ path: "auth", version: "1" })
+export class TokenReissueController {
+  constructor(private readonly commandBus: CommandBus) {}
+
+  @Get("reissue")
+  @UseGuards(ReissueTokenGuard)
+  @ApiOperation({ summary: "토큰 재발급" })
+  @ApiBearerAuth(SwaggerAuth.AUTH_AT)
+  @ApiOkResponse({
+    type: TokenReissueResponseDto,
+  })
+  reissueToken(@User() user: UserPayload) {
+    return this.commandBus.execute(
+      new TokenReissueCommand(user.userId, user.sessionId)
+    );
+  }
+}

--- a/src/auth/commands/token-reissue/token-reissue.dto.ts
+++ b/src/auth/commands/token-reissue/token-reissue.dto.ts
@@ -1,0 +1,7 @@
+export class TokenReissueResponseDto {
+  /**
+   * Access Token
+   * @example 'token'
+   */
+  AT: string;
+}

--- a/src/auth/commands/token-reissue/token-reissue.handler.ts
+++ b/src/auth/commands/token-reissue/token-reissue.handler.ts
@@ -1,0 +1,45 @@
+import { CommandHandler, ICommandHandler } from "@nestjs/cqrs";
+import { TokenReissueCommand } from "./token-reissue.command";
+import { EntityManager } from "typeorm";
+import { RefreshToken } from "src/database";
+import { JwtManagerService } from "src/common";
+import { InjectEntityManager } from "@nestjs/typeorm";
+import { RefreshTokenMapper } from "src/auth/mappers";
+
+@CommandHandler(TokenReissueCommand)
+export class TokenReissueCommandHandler
+  implements ICommandHandler<TokenReissueCommand>
+{
+  constructor(
+    @InjectEntityManager()
+    private readonly manager: EntityManager,
+    private readonly jwtManager: JwtManagerService
+  ) {}
+
+  async execute(command: TokenReissueCommand) {
+    const { userId, sessionId } = command;
+
+    const findRT = await this.manager.findOne(RefreshToken, {
+      where: {
+        userId,
+        sessionId,
+      },
+    });
+
+    if (!findRT) {
+      throw new Error("Refresh token이 존재하지 않습니다.");
+    }
+
+    const domain = RefreshTokenMapper.toDomain(findRT);
+
+    const isValid = await this.jwtManager.verifyRefreshToken(
+      domain.getProps().token
+    );
+
+    if (!isValid) {
+      throw new Error("유효하지 않은 Refresh token입니다.");
+    }
+
+    return { AT: await this.jwtManager.generateAccessToken(userId, sessionId) };
+  }
+}

--- a/src/auth/commands/withdrawal/index.ts
+++ b/src/auth/commands/withdrawal/index.ts
@@ -1,0 +1,3 @@
+export * from "./withdrawal.command";
+export * from "./withdrawal.controller";
+export * from "./withdrawal.handler";

--- a/src/auth/commands/withdrawal/withdrawal.command.ts
+++ b/src/auth/commands/withdrawal/withdrawal.command.ts
@@ -1,0 +1,5 @@
+import { ICommand } from "@nestjs/cqrs";
+
+export class WithdrawalCommand implements ICommand {
+  constructor(public readonly userId: string) {}
+}

--- a/src/auth/commands/withdrawal/withdrawal.controller.ts
+++ b/src/auth/commands/withdrawal/withdrawal.controller.ts
@@ -1,0 +1,19 @@
+import { Controller, Post, UseGuards } from "@nestjs/common";
+import { CommandBus } from "@nestjs/cqrs";
+import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
+import { AccessTokenGuard, SwaggerAuth, User, UserPayload } from "src/common";
+import { WithdrawalCommand } from "./withdrawal.command";
+
+@ApiTags("Auth")
+@Controller({ path: "auth", version: "1" })
+export class WithdrawalController {
+  constructor(private readonly commandBus: CommandBus) {}
+
+  @Post("withdrawal")
+  @UseGuards(AccessTokenGuard)
+  @ApiOperation({ summary: "회원탈퇴" })
+  @ApiBearerAuth(SwaggerAuth.AUTH_AT)
+  withdrawal(@User() user: UserPayload) {
+    return this.commandBus.execute(new WithdrawalCommand(user.userId));
+  }
+}

--- a/src/auth/commands/withdrawal/withdrawal.handler.ts
+++ b/src/auth/commands/withdrawal/withdrawal.handler.ts
@@ -1,0 +1,25 @@
+import { CommandHandler, ICommandHandler } from "@nestjs/cqrs";
+import { WithdrawalCommand } from "./withdrawal.command";
+import { InjectEntityManager } from "@nestjs/typeorm";
+import { EntityManager } from "typeorm";
+import { User } from "src/database";
+
+@CommandHandler(WithdrawalCommand)
+export class WithdrawalCommandHandler
+  implements ICommandHandler<WithdrawalCommand>
+{
+  constructor(
+    @InjectEntityManager()
+    private readonly manager: EntityManager
+  ) {}
+
+  async execute(command: WithdrawalCommand): Promise<void> {
+    const result = await this.manager.delete(User, {
+      id: command.userId,
+    });
+
+    if (!result.affected) {
+      throw new Error("회원탈퇴 실패했습니다.");
+    }
+  }
+}

--- a/src/auth/common/auth.injector.ts
+++ b/src/auth/common/auth.injector.ts
@@ -1,0 +1,3 @@
+export const AuthInjector = {
+  KAKAO_GUARD: "KAKAO_GUARD",
+} as const;

--- a/src/auth/common/index.ts
+++ b/src/auth/common/index.ts
@@ -1,0 +1,2 @@
+export * from "./auth.injector";
+export * from "./passport.constant";

--- a/src/auth/common/passport.constant.ts
+++ b/src/auth/common/passport.constant.ts
@@ -1,0 +1,3 @@
+export const PassportStrategyName = {
+  KAKAO: "kakao",
+} as const;

--- a/src/auth/decorators/index.ts
+++ b/src/auth/decorators/index.ts
@@ -1,0 +1,1 @@
+export * from "./social.decorator";

--- a/src/auth/decorators/social.decorator.ts
+++ b/src/auth/decorators/social.decorator.ts
@@ -1,0 +1,10 @@
+import { createParamDecorator, ExecutionContext } from "@nestjs/common";
+import { SocialPayload } from "../interfaces";
+
+export const Social = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext): SocialPayload => {
+    const request = ctx.switchToHttp().getRequest();
+
+    return request.user as SocialPayload;
+  }
+);

--- a/src/auth/domain/auth-social.ts
+++ b/src/auth/domain/auth-social.ts
@@ -1,0 +1,48 @@
+import { DomainEntity, UUID } from "src/common";
+import { SocialCodeVO } from "./social-code.vo";
+
+interface AuthSocialProps {
+  externalId: string;
+  socialCode: SocialCodeVO;
+  userId: UUID;
+}
+
+interface CreateAuthSocialProps {
+  externalId: string;
+  socialCode: SocialCodeVO;
+  userId: string;
+}
+
+export class AuthSocial extends DomainEntity<UUID, AuthSocialProps> {
+  static create(props: CreateAuthSocialProps) {
+    return new AuthSocial({
+      id: UUID.create(),
+      props: {
+        externalId: props.externalId,
+        socialCode: props.socialCode,
+        userId: UUID.create(props.userId),
+      },
+    });
+  }
+
+  validate() {
+    if (!this.id) {
+      throw new Error("ID 존재하지 않습니다.");
+    }
+    if (!this.props.externalId) {
+      throw new Error("External ID 존재하지 않습니다.");
+    }
+    if (
+      this.props.externalId.length < 1 ||
+      this.props.externalId.length > 255
+    ) {
+      throw new Error("External ID  1 ~ 255 자 사이여야 합니다.");
+    }
+    if (!(this.props.socialCode instanceof SocialCodeVO)) {
+      throw new Error("socialCode는 SocialCodeVO 인스턴스여야 합니다.");
+    }
+    if (!this.props.userId) {
+      throw new Error("User ID 존재하지 않습니다.");
+    }
+  }
+}

--- a/src/auth/domain/index.ts
+++ b/src/auth/domain/index.ts
@@ -1,0 +1,3 @@
+export * from "./auth-social";
+export * from "./social-code.vo";
+export * from "./refresh-token";

--- a/src/auth/domain/refresh-token.ts
+++ b/src/auth/domain/refresh-token.ts
@@ -1,0 +1,53 @@
+import { DomainEntity, UUID } from "src/common";
+import * as ms from "ms";
+
+interface RefreshTokenProps {
+  userId: UUID;
+  token: string;
+  sessionId: UUID;
+  expiredAt: Date;
+}
+
+interface CreaTeRefreshTokenProps {
+  userId: string;
+  token: string;
+  sessionId: string;
+  expiredAt: string;
+}
+
+export class RefreshToken extends DomainEntity<UUID, RefreshTokenProps> {
+  static create(props: CreaTeRefreshTokenProps): RefreshToken {
+    return new RefreshToken({
+      id: UUID.create(),
+      props: {
+        userId: UUID.create(props.userId),
+        token: props.token,
+        sessionId: UUID.create(props.sessionId),
+        expiredAt: new Date(Date.now() + ms(props.expiredAt)),
+      },
+    });
+  }
+
+  validate() {
+    if (!this.id) {
+      throw new Error("ID 존재하지 않습니다.");
+    }
+    if (!this.props.userId) {
+      throw new Error("User ID 존재하지 않습니다.");
+    }
+
+    if (
+      !this.props.token ||
+      this.props.token.length < 1 ||
+      this.props.token.length > 255
+    ) {
+      throw new Error("Token 1 ~ 255 자 사이여야 합니다.");
+    }
+    if (!this.props.sessionId) {
+      throw new Error("Session ID 존재하지 않습니다.");
+    }
+    if (this.props.expiredAt.getTime() < Date.now()) {
+      throw new Error("Expired At은 현재 시점 이후여야 합니다.");
+    }
+  }
+}

--- a/src/auth/domain/social-code.vo.ts
+++ b/src/auth/domain/social-code.vo.ts
@@ -1,0 +1,15 @@
+import { ValueObject } from "src/common";
+
+export class SocialCodeVO extends ValueObject<number> {
+  static create(value: number): SocialCodeVO {
+    return new SocialCodeVO(value);
+  }
+
+  protected validate(): void {
+    if (![1].includes(this.value)) {
+      throw new Error("유효하지 않은 소셜 코드입니다.");
+    }
+  }
+
+  static KAKAO = new SocialCodeVO(1);
+}

--- a/src/auth/guards/index.ts
+++ b/src/auth/guards/index.ts
@@ -1,0 +1,2 @@
+export * from "./kakao-auth.guard";
+export * from "./reissue-token.guard";

--- a/src/auth/guards/kakao-auth.guard.ts
+++ b/src/auth/guards/kakao-auth.guard.ts
@@ -1,0 +1,6 @@
+import { Injectable } from "@nestjs/common";
+import { AuthGuard } from "@nestjs/passport";
+import { PassportStrategyName } from "../common";
+
+@Injectable()
+export class KakaoAuthGuard extends AuthGuard(PassportStrategyName.KAKAO) {}

--- a/src/auth/guards/reissue-token.guard.ts
+++ b/src/auth/guards/reissue-token.guard.ts
@@ -1,0 +1,37 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from "@nestjs/common";
+import { JwtManagerService } from "src/common";
+
+@Injectable()
+export class ReissueTokenGuard implements CanActivate {
+  constructor(private readonly jwtManager: JwtManagerService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const authHeader = request.headers.authorization;
+    const token = authHeader?.replace("Bearer ", "");
+
+    if (!token) {
+      throw new UnauthorizedException(
+        "요청 헤더에 Authorization 이 존재하지 않습니다."
+      );
+    }
+
+    const decoded = await this.jwtManager.decodeAccessToken(token);
+
+    if (!decoded || !decoded.userId || !decoded.sessionId) {
+      throw new UnauthorizedException("유효하지 않은 토큰입니다.");
+    }
+
+    request.user = {
+      userId: decoded.userId,
+      sessionId: decoded.sessionId,
+    };
+
+    return true;
+  }
+}

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,0 +1,5 @@
+export * from "./auth.module";
+export * from "./common";
+export * from "./guards";
+export * from "./interfaces";
+export * from "./mappers";

--- a/src/auth/interfaces/index.ts
+++ b/src/auth/interfaces/index.ts
@@ -1,0 +1,2 @@
+export * from "./user-payload.interface";
+export * from "./social-login-payload.interface";

--- a/src/auth/interfaces/social-login-payload.interface.ts
+++ b/src/auth/interfaces/social-login-payload.interface.ts
@@ -1,0 +1,6 @@
+export class SocialPayload {
+  externalId: string;
+  name: string;
+  profile: string;
+  email: string;
+}

--- a/src/auth/interfaces/user-payload.interface.ts
+++ b/src/auth/interfaces/user-payload.interface.ts
@@ -1,0 +1,3 @@
+export interface UserPayload {
+  userId: string;
+}

--- a/src/auth/mappers/auth-social.mapper.ts
+++ b/src/auth/mappers/auth-social.mapper.ts
@@ -1,0 +1,28 @@
+import { UUID } from "src/common";
+import { AuthSocial, SocialCodeVO } from "../domain";
+import { AuthSocial as AuthSocialEntity } from "src/database";
+
+export class AuthSocialMapper {
+  static toPersistence(authSocial: AuthSocial): AuthSocialEntity {
+    const props = authSocial.getProps();
+
+    const entity = new AuthSocialEntity();
+    entity.id = authSocial.id.unpack();
+    entity.externalId = props.externalId;
+    entity.socialCode = props.socialCode.value; // VO 사용
+    entity.userId = props.userId.unpack();
+
+    return entity;
+  }
+
+  static toDomain(entity: AuthSocialEntity): AuthSocial {
+    return new AuthSocial({
+      id: UUID.create(entity.id),
+      props: {
+        externalId: entity.externalId,
+        socialCode: SocialCodeVO.create(entity.socialCode),
+        userId: UUID.create(entity.userId),
+      },
+    });
+  }
+}

--- a/src/auth/mappers/index.ts
+++ b/src/auth/mappers/index.ts
@@ -1,0 +1,2 @@
+export * from "./refresh-token.mapper";
+export * from "./auth-social.mapper";

--- a/src/auth/mappers/refresh-token.mapper.ts
+++ b/src/auth/mappers/refresh-token.mapper.ts
@@ -1,0 +1,30 @@
+import { UUID } from "src/common";
+import { RefreshToken } from "../domain";
+import { RefreshToken as RefreshTokenEntity } from "src/database";
+
+export class RefreshTokenMapper {
+  static toPersistence(refreshToken: RefreshToken): RefreshTokenEntity {
+    const props = refreshToken.getProps();
+
+    const entity = new RefreshTokenEntity();
+    entity.id = refreshToken.id.unpack();
+    entity.userId = props.userId.unpack();
+    entity.token = props.token;
+    entity.sessionId = props.sessionId.unpack();
+    entity.expiredAt = props.expiredAt;
+
+    return entity;
+  }
+
+  static toDomain(entity: RefreshTokenEntity): RefreshToken {
+    return new RefreshToken({
+      id: UUID.create(entity.id),
+      props: {
+        userId: UUID.create(entity.userId),
+        token: entity.token,
+        sessionId: UUID.create(entity.sessionId),
+        expiredAt: entity.expiredAt,
+      },
+    });
+  }
+}

--- a/src/auth/strategies/index.ts
+++ b/src/auth/strategies/index.ts
@@ -1,0 +1,1 @@
+export * from "./kakao.strategy";

--- a/src/auth/strategies/kakao.strategy.ts
+++ b/src/auth/strategies/kakao.strategy.ts
@@ -1,0 +1,35 @@
+import { Inject, Injectable } from "@nestjs/common";
+import { PassportStrategy } from "@nestjs/passport";
+import { Strategy } from "passport-kakao";
+import {
+  ConfigurationServiceInjector,
+  KakaoConfigService,
+} from "src/configuration";
+import { PassportStrategyName } from "../common";
+
+@Injectable()
+export class KakaoStrategy extends PassportStrategy(
+  Strategy,
+  PassportStrategyName.KAKAO
+) {
+  constructor(
+    @Inject(ConfigurationServiceInjector.KAKAO_SERVICE)
+    private readonly kakaoConfigService: KakaoConfigService
+  ) {
+    super({
+      clientID: kakaoConfigService.restAPI,
+      clientSecret: kakaoConfigService.clientSecret,
+      callbackURL: kakaoConfigService.callbackURL,
+      scope: ["profile_image", "profile_nickname", "account_email"],
+    });
+  }
+
+  async validate(accessToken: string, refreshToken: string, profile: any) {
+    return {
+      externalId: profile._json.id,
+      name: profile._json.properties.nickname,
+      profile: profile._json.properties.profile_image,
+      email: profile._json.kakao_account.email,
+    };
+  }
+}

--- a/src/auth/test/commands/kakao-login.handler.spec.ts
+++ b/src/auth/test/commands/kakao-login.handler.spec.ts
@@ -1,0 +1,186 @@
+import { EntityManager } from "typeorm";
+import {
+  ConfigurationServiceInjector,
+  TokenConfigService,
+} from "src/configuration";
+import { User } from "src/user";
+import { KaKaoLoginCommand, KaKaoLoginCommandHandler } from "../../commands";
+import { Test, TestingModule } from "@nestjs/testing";
+import {
+  AuthSocial as AuthSocialEntity,
+  RefreshToken as RefreshTokenEntity,
+  User as UserEntity,
+  MockEntityManager,
+} from "src/database";
+import { AuthSocial, RefreshToken, SocialCodeVO } from "../../domain";
+import { JwtManagerService } from "src/common";
+
+describe("KaKaoLoginCommandHandler", () => {
+  let handler: KaKaoLoginCommandHandler;
+  let manager: EntityManager;
+  let jwtManager: JwtManagerService;
+  let tokenConfig: TokenConfigService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        KaKaoLoginCommandHandler,
+        {
+          provide: EntityManager,
+          useFactory: MockEntityManager,
+        },
+        {
+          provide: JwtManagerService,
+          useValue: {
+            generateAccessToken: jest.fn(),
+            generateRefreshToken: jest.fn(),
+          },
+        },
+        {
+          provide: ConfigurationServiceInjector.TOKEN_SERVICE,
+          useValue: {
+            refreshTokenExpiresIn: "7d",
+          },
+        },
+      ],
+    }).compile();
+
+    handler = module.get<KaKaoLoginCommandHandler>(KaKaoLoginCommandHandler);
+    manager = module.get<EntityManager>(EntityManager);
+    jwtManager = module.get<JwtManagerService>(JwtManagerService);
+    tokenConfig = module.get<TokenConfigService>(
+      ConfigurationServiceInjector.TOKEN_SERVICE
+    );
+  });
+
+  const command = new KaKaoLoginCommand(
+    "userExistId",
+    "d_o0o_b",
+    "http://profile.image",
+    "d_o0o_b@gmail.com"
+  );
+
+  describe("execute", () => {
+    it("기존 유저가 존재하면 유저를 생성하지 않는다", async () => {
+      const existingUser = { userId: "userExist" };
+      const findOne = jest
+        .spyOn(manager, "findOne")
+        .mockResolvedValue(existingUser);
+
+      jest.spyOn(RefreshToken, "create").mockReturnValue({
+        id: {
+          unpack: () => jest.fn(),
+        },
+        getProps: () => jest.fn(),
+      } as any);
+
+      const insert = jest.spyOn(manager, "insert");
+
+      const generateAccessToken = jest
+        .spyOn(jwtManager, "generateAccessToken")
+        .mockResolvedValue("ACCESS_TOKEN");
+
+      const generateRefreshToken = jest
+        .spyOn(jwtManager, "generateRefreshToken")
+        .mockResolvedValue("REFRESH_TOKEN");
+
+      const result = await handler.execute(command);
+
+      expect(result).toEqual({ AT: "ACCESS_TOKEN", RT: "REFRESH_TOKEN" });
+
+      expect(findOne).toHaveBeenCalledTimes(1);
+      expect(findOne).toHaveBeenCalledWith(AuthSocialEntity, {
+        where: {
+          externalId: command.externalId,
+          socialCode: SocialCodeVO.KAKAO.value,
+        },
+      });
+
+      expect(tokenConfig.refreshTokenExpiresIn).toBe("7d");
+
+      expect(insert).toHaveBeenCalledTimes(1);
+      expect(insert).toHaveBeenCalledWith(
+        RefreshTokenEntity,
+        expect.any(Object)
+      );
+
+      expect(generateAccessToken).toHaveBeenCalledWith(
+        existingUser.userId,
+        expect.any(String)
+      );
+      expect(generateRefreshToken).toHaveBeenCalledWith(existingUser.userId);
+    });
+
+    it("유저가 존재하지 않으면 새 유저와 소셜 계정을 생성한다", async () => {
+      const findOne = jest.spyOn(manager, "findOne").mockResolvedValue(null);
+
+      const insert = jest.spyOn(manager, "insert");
+
+      jest.spyOn(User, "create").mockReturnValue({
+        id: {
+          unpack: () => jest.fn(),
+        },
+        getProps: () => jest.fn(),
+      } as any);
+
+      jest.spyOn(AuthSocial, "create").mockReturnValue({
+        id: {
+          unpack: () => jest.fn(),
+        },
+        getProps: () => ({
+          externalId: command.externalId,
+          socialCode: SocialCodeVO.KAKAO,
+          userId: "newUserId",
+        }),
+      } as any);
+
+      jest.spyOn(RefreshToken, "create").mockReturnValue({
+        id: {
+          unpack: () => jest.fn(),
+        },
+        getProps: () => jest.fn(),
+      } as any);
+
+      const generateAccessToken = jest
+        .spyOn(jwtManager, "generateAccessToken")
+        .mockResolvedValue("ACCESS_TOKEN");
+
+      const generateRefreshToken = jest
+        .spyOn(jwtManager, "generateRefreshToken")
+        .mockResolvedValue("REFRESH_TOKEN");
+
+      const result = await handler.execute(command);
+
+      expect(findOne).toHaveBeenCalledTimes(1);
+      expect(findOne).toHaveBeenCalledWith(AuthSocialEntity, {
+        where: {
+          externalId: command.externalId,
+          socialCode: SocialCodeVO.KAKAO.value,
+        },
+      });
+
+      expect(tokenConfig.refreshTokenExpiresIn).toBe("7d");
+
+      expect(insert).toHaveBeenCalledTimes(3);
+      expect(insert).toHaveBeenNthCalledWith(1, UserEntity, expect.any(Object));
+      expect(insert).toHaveBeenNthCalledWith(
+        2,
+        AuthSocialEntity,
+        expect.any(Object)
+      );
+      expect(insert).toHaveBeenNthCalledWith(
+        3,
+        RefreshTokenEntity,
+        expect.any(Object)
+      );
+
+      expect(generateAccessToken).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.any(String)
+      );
+      expect(generateRefreshToken).toHaveBeenCalledWith(expect.any(Object));
+
+      expect(result).toEqual({ AT: "ACCESS_TOKEN", RT: "REFRESH_TOKEN" });
+    });
+  });
+});

--- a/src/auth/test/commands/logout.handler.spec.ts
+++ b/src/auth/test/commands/logout.handler.spec.ts
@@ -1,0 +1,53 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { LogoutCommand, LogoutCommandHandler } from "../../commands";
+import { RefreshToken } from "src/database";
+import { EntityManager } from "typeorm";
+import { randomUUID } from "crypto";
+
+describe("LogoutCommandHandler", () => {
+  let handler: LogoutCommandHandler;
+  let manager: EntityManager;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LogoutCommandHandler,
+        {
+          provide: EntityManager,
+          useValue: {
+            delete: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    handler = module.get<LogoutCommandHandler>(LogoutCommandHandler);
+    manager = module.get<EntityManager>(EntityManager);
+  });
+
+  const command = new LogoutCommand(randomUUID(), randomUUID());
+
+  describe("execute", () => {
+    it("유저의 RT를 삭제한다", async () => {
+      const deleteSpy = jest.spyOn(manager, "delete").mockResolvedValue({
+        affected: 1,
+      } as any);
+
+      await handler.execute(command);
+      expect(deleteSpy).toHaveBeenCalledWith(RefreshToken, {
+        userId: command.userId,
+        sessionId: command.sessionId,
+      });
+    });
+
+    it("RT 삭제 실패시 예외를 발생한다", async () => {
+      jest.spyOn(manager, "delete").mockResolvedValue({
+        affected: 0,
+      } as any);
+
+      await expect(handler.execute(command)).rejects.toThrow(
+        "Refresh token 삭제 실패했습니다."
+      );
+    });
+  });
+});

--- a/src/auth/test/commands/token-reissue.handler.spec.ts
+++ b/src/auth/test/commands/token-reissue.handler.spec.ts
@@ -1,0 +1,155 @@
+import { EntityManager } from "typeorm";
+import {
+  TokenReissueCommand,
+  TokenReissueCommandHandler,
+} from "../../commands";
+import { Test, TestingModule } from "@nestjs/testing";
+import { JwtManagerService } from "src/common";
+import { RefreshToken } from "src/database";
+import { randomUUID } from "crypto";
+
+describe("TokenReissueCommandHandler", () => {
+  let handler: TokenReissueCommandHandler;
+  let manager: EntityManager;
+  let jwtManager: JwtManagerService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TokenReissueCommandHandler,
+        {
+          provide: EntityManager,
+          useValue: {
+            findOne: jest.fn(),
+          },
+        },
+        {
+          provide: JwtManagerService,
+          useValue: {
+            verifyRefreshToken: jest.fn(),
+            generateAccessToken: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    handler = module.get<TokenReissueCommandHandler>(
+      TokenReissueCommandHandler
+    );
+    manager = module.get<EntityManager>(EntityManager);
+    jwtManager = module.get<JwtManagerService>(JwtManagerService);
+  });
+
+  const command = new TokenReissueCommand(randomUUID(), randomUUID());
+
+  describe("execute", () => {
+    it("AT을 재발급한다", async () => {
+      const mockRefreshToken = {
+        id: randomUUID(),
+        userId: command.userId,
+        token: "valid-refresh-token",
+        sessionId: command.sessionId,
+        expiredAt: new Date(Date.now() + 1000 * 60 * 10), // 10분 후
+      };
+
+      const findOne = jest
+        .spyOn(manager, "findOne")
+        .mockResolvedValue(mockRefreshToken);
+
+      const verifyRefreshToken = jest
+        .spyOn(jwtManager, "verifyRefreshToken")
+        .mockResolvedValue({
+          userId: command.userId,
+        });
+
+      const generateAccessToken = jest
+        .spyOn(jwtManager, "generateAccessToken")
+        .mockResolvedValue("new-access-token");
+
+      const result = await handler.execute(command);
+
+      expect(result.AT).toBe("new-access-token");
+      expect(findOne).toHaveBeenCalledWith(RefreshToken, {
+        where: {
+          userId: command.userId,
+          sessionId: command.sessionId,
+        },
+      });
+      expect(verifyRefreshToken).toHaveBeenCalledWith(mockRefreshToken.token);
+      expect(generateAccessToken).toHaveBeenCalledWith(
+        command.userId,
+        command.sessionId
+      );
+    });
+
+    it("RT가 존재하지 않을 경우 에러를 발생한다", async () => {
+      const findOne = jest.spyOn(manager, "findOne").mockResolvedValue(null);
+
+      await expect(handler.execute(command)).rejects.toThrow(
+        "Refresh token이 존재하지 않습니다."
+      );
+
+      expect(findOne).toHaveBeenCalledWith(RefreshToken, {
+        where: {
+          userId: command.userId,
+          sessionId: command.sessionId,
+        },
+      });
+    });
+
+    it("RT가 만료되었을 경우 에러를 발생한다", async () => {
+      const expiredRT = {
+        id: randomUUID(),
+        userId: command.userId,
+        token: "expired-token",
+        sessionId: command.sessionId,
+        expiredAt: new Date(Date.now() - 1000 * 60), // 1분 전
+      };
+
+      const findOne = jest
+        .spyOn(manager, "findOne")
+        .mockResolvedValue(expiredRT);
+
+      await expect(handler.execute(command)).rejects.toThrow(
+        "Expired At은 현재 시점 이후여야 합니다."
+      );
+
+      expect(findOne).toHaveBeenCalledWith(RefreshToken, {
+        where: {
+          userId: command.userId,
+          sessionId: command.sessionId,
+        },
+      });
+    });
+
+    it("RT가 유효하지 않을 경우 에러를 발생한다", async () => {
+      const mockRefreshToken = {
+        id: randomUUID(),
+        userId: command.userId,
+        token: "invalid-token",
+        sessionId: command.sessionId,
+        expiredAt: new Date(Date.now() + 1000 * 60 * 10),
+      };
+
+      const findOne = jest
+        .spyOn(manager, "findOne")
+        .mockResolvedValue(mockRefreshToken);
+
+      const verifyRefreshToken = jest
+        .spyOn(jwtManager, "verifyRefreshToken")
+        .mockResolvedValue(null);
+
+      await expect(handler.execute(command)).rejects.toThrow(
+        "유효하지 않은 Refresh token입니다."
+      );
+
+      expect(findOne).toHaveBeenCalledWith(RefreshToken, {
+        where: {
+          userId: command.userId,
+          sessionId: command.sessionId,
+        },
+      });
+      expect(verifyRefreshToken).toHaveBeenCalledWith(mockRefreshToken.token);
+    });
+  });
+});

--- a/src/auth/test/commands/withdrawal.handler.spec.ts
+++ b/src/auth/test/commands/withdrawal.handler.spec.ts
@@ -1,0 +1,50 @@
+import { EntityManager } from "typeorm";
+import { WithdrawalCommand, WithdrawalCommandHandler } from "../../commands";
+import { Test, TestingModule } from "@nestjs/testing";
+import { User } from "src/database";
+import { randomUUID } from "crypto";
+
+describe("WithdrawalCommandHandler", () => {
+  let handler: WithdrawalCommandHandler;
+  let manager: EntityManager;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WithdrawalCommandHandler,
+        {
+          provide: EntityManager,
+          useValue: {
+            delete: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    handler = module.get<WithdrawalCommandHandler>(WithdrawalCommandHandler);
+    manager = module.get<EntityManager>(EntityManager);
+  });
+
+  const command = new WithdrawalCommand(randomUUID());
+
+  describe("execute", () => {
+    it("유저를 삭제한다", async () => {
+      const deleteSpy = jest.spyOn(manager, "delete").mockResolvedValue({
+        affected: 1,
+      } as any);
+
+      await handler.execute(command);
+      expect(deleteSpy).toHaveBeenCalledWith(User, { id: command.userId });
+    });
+
+    it("유저 삭제 실패시 예외를 발생한다", async () => {
+      jest.spyOn(manager, "delete").mockResolvedValue({
+        affected: 0,
+      } as any);
+
+      await expect(handler.execute(command)).rejects.toThrow(
+        "회원탈퇴 실패했습니다."
+      );
+    });
+  });
+});

--- a/src/auth/test/domain/auth-social.spec.ts
+++ b/src/auth/test/domain/auth-social.spec.ts
@@ -1,0 +1,57 @@
+import { AuthSocial, SocialCodeVO } from "src/auth/domain";
+import { UUID } from "src/common";
+import copy from "fast-copy";
+
+describe("AuthSocial", () => {
+  const validProps = {
+    externalId: "social-123",
+    socialCode: SocialCodeVO.KAKAO,
+    userId: UUID.create().unpack(),
+  };
+
+  describe("create", () => {
+    it("정상적으로 AuthSocial을 생성한다", () => {
+      const authSocial = AuthSocial.create(validProps);
+
+      expect(authSocial).toBeInstanceOf(AuthSocial);
+      expect(authSocial.id).toBeInstanceOf(UUID);
+      expect(authSocial.getProps().externalId).toEqual(validProps.externalId);
+      expect(authSocial.getProps().socialCode).toBeInstanceOf(SocialCodeVO);
+      expect(authSocial.getProps().userId).toBeInstanceOf(UUID);
+    });
+  });
+
+  describe("validate", () => {
+    it("externalId가 없으면 예외가 발생한다", () => {
+      const p = copy(validProps);
+      p.externalId = "";
+      expect(() => AuthSocial.create(p)).toThrow(
+        "External ID 존재하지 않습니다."
+      );
+    });
+
+    it("externalId가 256자 이상이면 예외가 발생한다", () => {
+      const p = copy(validProps);
+      p.externalId = "a".repeat(256);
+      expect(() => AuthSocial.create(p)).toThrow(
+        "External ID  1 ~ 255 자 사이여야 합니다."
+      );
+    });
+
+    it("socialCode가 SocialCodeVO 인스턴스가 아니면 예외가 발생한다", () => {
+      const p = copy(validProps);
+      p.socialCode = "kakao" as any;
+      expect(() => AuthSocial.create(p)).toThrow(
+        "socialCode는 SocialCodeVO 인스턴스여야 합니다."
+      );
+    });
+
+    it.skip("userId가 없으면 예외가 발생한다", () => {
+      const p = copy(validProps);
+      p.userId = undefined as any;
+      expect(() => AuthSocial.create(p)).toThrow(
+        "UUID 값이 존재하지 않습니다."
+      );
+    });
+  });
+});

--- a/src/auth/test/domain/refresh-token.spec.ts
+++ b/src/auth/test/domain/refresh-token.spec.ts
@@ -1,0 +1,73 @@
+import { randomUUID } from "crypto";
+import { RefreshToken } from "../../domain";
+import { UUID } from "src/common";
+import copy from "fast-copy";
+
+describe("RefreshToken", () => {
+  const validProps = {
+    userId: randomUUID(),
+    token: "valid-token",
+    sessionId: randomUUID(),
+    expiredAt: "1h",
+  };
+
+  describe("create", () => {
+    it("정상적으로 RefreshToken을 생성한다", () => {
+      const token = RefreshToken.create(validProps);
+
+      expect(token).toBeInstanceOf(RefreshToken);
+      expect(token.id).toBeInstanceOf(UUID);
+      expect(token.getProps().userId.unpack()).toEqual(validProps.userId);
+    });
+  });
+
+  describe("validate", () => {
+    it.skip("userId가 없으면 예외가 발생한다", () => {
+      const p = copy(validProps);
+      p.userId = null as any;
+      expect(() => RefreshToken.create(p)).toThrow(
+        "UUID 값이 존재하지 않습니다."
+      );
+    });
+
+    it("token이 빈 문자열이면 예외가 발생한다", () => {
+      const p = copy(validProps);
+      p.token = "";
+      expect(() => RefreshToken.create(p)).toThrow(
+        "Token 1 ~ 255 자 사이여야 합니다."
+      );
+    });
+
+    it("token이 256자 이상이면 예외가 발생한다", () => {
+      const p = copy(validProps);
+      p.token = "a".repeat(256);
+      expect(() => RefreshToken.create(p)).toThrow(
+        "Token 1 ~ 255 자 사이여야 합니다."
+      );
+    });
+
+    it("sessionId가 잘못된 UUID면 예외가 발생한다", () => {
+      const p = copy(validProps);
+      p.sessionId = "not-uuid" as any;
+      expect(() => RefreshToken.create(p)).toThrow("Invalid Domain UUID");
+    });
+
+    it("expiredAt이 과거면 예외가 발생한다", () => {
+      const p = copy(validProps);
+      p.expiredAt = "-1m";
+      expect(() => RefreshToken.create(p)).toThrow(
+        "Expired At은 현재 시점 이후여야 합니다."
+      );
+    });
+
+    it("expiredAt이 현재보다 이후 시간이라면 정상 생성된다", () => {
+      const p = copy(validProps);
+      p.expiredAt = "30m";
+
+      const token = RefreshToken.create(p);
+
+      expect(token).toBeInstanceOf(RefreshToken);
+      expect(token.getProps().expiredAt.getTime()).toBeGreaterThan(Date.now());
+    });
+  });
+});

--- a/src/auth/test/domain/social-code.vo.spec.ts
+++ b/src/auth/test/domain/social-code.vo.spec.ts
@@ -1,0 +1,47 @@
+import { SocialCodeVO } from "../../domain";
+
+describe("SocialCodeVO", () => {
+  describe("create", () => {
+    it("KAKAO는 value가 1인 인스턴스여야 한다", () => {
+      const kakao = SocialCodeVO.KAKAO;
+
+      expect(kakao).toBeInstanceOf(SocialCodeVO);
+      expect(kakao.value).toBe(1);
+    });
+  });
+
+  describe("validate", () => {
+    it("허용된 코드(1)로 생성하면 정상적으로 생성된다", () => {
+      const vo = SocialCodeVO.create(1);
+      expect(vo.value).toBe(1);
+    });
+
+    it("허용되지 않은 코드로 생성하면 예외를 발생한다", () => {
+      expect(() => SocialCodeVO.create(99)).toThrow(
+        "유효하지 않은 소셜 코드입니다."
+      );
+      expect(() => SocialCodeVO.create(0)).toThrow(
+        "유효하지 않은 소셜 코드입니다."
+      );
+      expect(() => SocialCodeVO.create(-1)).toThrow(
+        "유효하지 않은 소셜 코드입니다."
+      );
+    });
+  });
+
+  describe("equals", () => {
+    it("값이 같으면 true를 반환한다", () => {
+      const a = SocialCodeVO.create(1);
+      const b = SocialCodeVO.create(1);
+
+      expect(a.equals(b)).toBe(true);
+    });
+
+    it("값이 다르면 false를 반환한다", () => {
+      const a = SocialCodeVO.create(1);
+      const b = { value: 2, equals: () => false } as any;
+
+      expect(a.equals(b)).toBe(false);
+    });
+  });
+});

--- a/src/auth/test/guards/reissue-token.guard.spec.ts
+++ b/src/auth/test/guards/reissue-token.guard.spec.ts
@@ -1,0 +1,117 @@
+import { JwtManagerService } from "src/common";
+import { ExecutionContext, UnauthorizedException } from "@nestjs/common";
+import { ReissueTokenGuard } from "../../guards";
+import { Test, TestingModule } from "@nestjs/testing";
+
+describe("ReissueTokenGuard", () => {
+  let guard: ReissueTokenGuard;
+  let jwtManager: JwtManagerService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReissueTokenGuard,
+        {
+          provide: JwtManagerService,
+          useValue: {
+            decodeAccessToken: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    guard = module.get<ReissueTokenGuard>(ReissueTokenGuard);
+    jwtManager = module.get<JwtManagerService>(JwtManagerService);
+  });
+
+  const mockRequest = (authHeader?: string): any => ({
+    headers: {
+      authorization: authHeader,
+    },
+  });
+
+  const mockContext = (request: any): ExecutionContext =>
+    ({
+      switchToHttp: () => ({
+        getRequest: () => request,
+      }),
+    } as unknown as ExecutionContext);
+
+  describe("canActivate", () => {
+    it("정상적인 토큰이면 user 정보 주입 후 true 반환한다", async () => {
+      const token = "Bearer valid.token.value";
+      const request = mockRequest(token);
+      const context = mockContext(request);
+
+      const decodedPayload = {
+        userId: "user-uuid",
+        sessionId: "session-uuid",
+      };
+
+      const decodeAccessToken = jest
+        .spyOn(jwtManager, "decodeAccessToken")
+        .mockResolvedValue(decodedPayload);
+
+      const result = await guard.canActivate(context);
+
+      expect(decodeAccessToken).toHaveBeenCalledWith(
+        token.replace("Bearer ", "")
+      );
+      expect(request.user).toEqual({
+        userId: decodedPayload.userId,
+        sessionId: decodedPayload.sessionId,
+      });
+      expect(result).toBe(true);
+    });
+
+    it("Authorization 헤더가 없으면 예외 발생한다", async () => {
+      const request = mockRequest(undefined);
+      const context = mockContext(request);
+
+      await expect(guard.canActivate(context)).rejects.toThrowError(
+        new UnauthorizedException(
+          "요청 헤더에 Authorization 이 존재하지 않습니다."
+        )
+      );
+    });
+
+    it("decodeAccessToken 결과에 userId 또는 sessionId가 없으면 예외 발생한다", async () => {
+      const token = "Bearer invalid.token";
+      const request = mockRequest(token);
+      const context = mockContext(request);
+
+      const decodeAccessToken = jest
+        .spyOn(jwtManager, "decodeAccessToken")
+        .mockResolvedValue({
+          userId: null,
+          sessionId: undefined,
+        });
+
+      await expect(guard.canActivate(context)).rejects.toThrowError(
+        new UnauthorizedException("유효하지 않은 토큰입니다.")
+      );
+
+      expect(decodeAccessToken).toHaveBeenCalledWith(
+        token.replace("Bearer ", "")
+      );
+    });
+
+    it("decodeAccessToken 결과가 null이면 예외 발생한다", async () => {
+      const token = "Bearer token.without.payload";
+      const request = mockRequest(token);
+      const context = mockContext(request);
+
+      const decodeAccessToken = jest
+        .spyOn(jwtManager, "decodeAccessToken")
+        .mockResolvedValue(null);
+
+      await expect(guard.canActivate(context)).rejects.toThrowError(
+        new UnauthorizedException("유효하지 않은 토큰입니다.")
+      );
+
+      expect(decodeAccessToken).toHaveBeenCalledWith(
+        token.replace("Bearer ", "")
+      );
+    });
+  });
+});

--- a/src/auth/test/mappers/auth-social.mapper.spec.ts
+++ b/src/auth/test/mappers/auth-social.mapper.spec.ts
@@ -1,0 +1,51 @@
+import { AuthSocialMapper } from "../../mappers";
+import { AuthSocial, SocialCodeVO } from "../../domain";
+import { UUID } from "src/common";
+import { AuthSocial as AuthSocialEntity } from "src/database";
+
+const createValidAuthSocialDomain = (): AuthSocial => {
+  return AuthSocial.create({
+    externalId: "external-id",
+    socialCode: SocialCodeVO.KAKAO,
+    userId: UUID.create().unpack(),
+  });
+};
+
+describe("AuthSocialMapper", () => {
+  describe("toPersistence", () => {
+    it("도메인 객체를 엔티티로 변환한다", () => {
+      const domain = createValidAuthSocialDomain();
+      const props = domain.getProps();
+
+      const entity = AuthSocialMapper.toPersistence(domain);
+
+      expect(entity).toBeInstanceOf(AuthSocialEntity);
+      expect(entity.id).toBe(domain.id.unpack());
+      expect(entity.externalId).toBe(props.externalId);
+      expect(entity.socialCode).toBe(props.socialCode.value);
+      expect(entity.userId).toBe(props.userId.unpack());
+    });
+  });
+
+  describe("toDomain", () => {
+    it("엔티티를 도메인 객체로 변환한다", () => {
+      const domain = createValidAuthSocialDomain();
+      const props = domain.getProps();
+
+      const entity = new AuthSocialEntity();
+      entity.id = domain.id.unpack();
+      entity.externalId = props.externalId;
+      entity.socialCode = props.socialCode.value;
+      entity.userId = props.userId.unpack();
+
+      const result = AuthSocialMapper.toDomain(entity);
+      const resultProps = result.getProps();
+
+      expect(result).toBeInstanceOf(AuthSocial);
+      expect(result.id.unpack()).toBe(entity.id);
+      expect(resultProps.externalId).toBe(entity.externalId);
+      expect(resultProps.socialCode.value).toBe(entity.socialCode);
+      expect(resultProps.userId.unpack()).toBe(entity.userId);
+    });
+  });
+});

--- a/src/auth/test/mappers/refresh-token.mapper.spec.ts
+++ b/src/auth/test/mappers/refresh-token.mapper.spec.ts
@@ -1,0 +1,55 @@
+import { RefreshTokenMapper } from "../../mappers";
+import { RefreshToken } from "../../domain";
+import { UUID } from "src/common";
+import { RefreshToken as RefreshTokenEntity } from "src/database";
+
+const createValidRefreshTokenDomain = (): RefreshToken => {
+  return RefreshToken.create({
+    userId: UUID.create().unpack(),
+    token: "test-refresh-token",
+    sessionId: UUID.create().unpack(),
+    expiredAt: "1h",
+  });
+};
+
+describe("RefreshTokenMapper", () => {
+  describe("toPersistence", () => {
+    it("도메인 객체를 엔티티로 변환한다", () => {
+      const domain = createValidRefreshTokenDomain();
+      const props = domain.getProps();
+
+      const entity = RefreshTokenMapper.toPersistence(domain);
+
+      expect(entity).toBeInstanceOf(RefreshTokenEntity);
+      expect(entity.id).toBe(domain.id.unpack());
+      expect(entity.userId).toBe(props.userId.unpack());
+      expect(entity.token).toBe(props.token);
+      expect(entity.sessionId).toBe(props.sessionId.unpack());
+      expect(entity.expiredAt.getTime()).toBe(props.expiredAt.getTime());
+    });
+  });
+
+  describe("toDomain", () => {
+    it("엔티티를 도메인 객체로 변환한다", () => {
+      const domain = createValidRefreshTokenDomain();
+      const props = domain.getProps();
+
+      const entity = new RefreshTokenEntity();
+      entity.id = domain.id.unpack();
+      entity.userId = props.userId.unpack();
+      entity.token = props.token;
+      entity.sessionId = props.sessionId.unpack();
+      entity.expiredAt = props.expiredAt;
+
+      const result = RefreshTokenMapper.toDomain(entity);
+      const resultProps = result.getProps();
+
+      expect(result).toBeInstanceOf(RefreshToken);
+      expect(result.id.unpack()).toBe(entity.id);
+      expect(resultProps.userId.unpack()).toBe(entity.userId);
+      expect(resultProps.token).toBe(entity.token);
+      expect(resultProps.sessionId.unpack()).toBe(entity.sessionId);
+      expect(resultProps.expiredAt.getTime()).toBe(entity.expiredAt.getTime());
+    });
+  });
+});

--- a/src/user/domain/index.ts
+++ b/src/user/domain/index.ts
@@ -1,0 +1,1 @@
+export * from "./user";

--- a/src/user/domain/user.ts
+++ b/src/user/domain/user.ts
@@ -1,0 +1,48 @@
+import { DomainEntity, UUID } from "src/common";
+
+interface UserProps {
+  name: string;
+  email: string;
+  profile: string;
+  emailActive?: boolean;
+}
+
+export class User extends DomainEntity<UUID, UserProps> {
+  static create(props: UserProps): User {
+    return new User({
+      id: UUID.create(),
+      props: {
+        name: props.name,
+        email: props.email,
+        profile: props.profile,
+        emailActive: props.emailActive ?? true, // 기본값은 true로 설정
+      },
+    });
+  }
+
+  validate() {
+    if (!this.id) {
+      throw new Error("ID 존재하지 않습니다.");
+    }
+    if (
+      !this.props.name ||
+      this.props.name.length < 1 ||
+      this.props.name.length > 10
+    ) {
+      throw new Error("Name 1 ~ 10 자 사이여야 합니다.");
+    }
+    if (
+      !this.props.email ||
+      this.props.email.length < 1 ||
+      this.props.email.length > 255 ||
+      !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(this.props.email)
+    ) {
+      throw new Error(
+        "Email은 1 ~ 255 자 사이의 유효한 이메일 형식이어야 합니다."
+      );
+    }
+    if (!this.props.profile) {
+      throw new Error("Profile 존재하지 않습니다.");
+    }
+  }
+}

--- a/src/user/index.ts
+++ b/src/user/index.ts
@@ -1,0 +1,2 @@
+export * from "./domain";
+export * from "./mappers";

--- a/src/user/mappers/index.ts
+++ b/src/user/mappers/index.ts
@@ -1,0 +1,1 @@
+export * from "./user.mapper";

--- a/src/user/mappers/user.mapper.ts
+++ b/src/user/mappers/user.mapper.ts
@@ -1,0 +1,30 @@
+import { UUID } from "src/common";
+import { User } from "../domain";
+import { User as UserEntity } from "src/database";
+
+export class UserMapper {
+  static toPersistence(user: User): UserEntity {
+    const props = user.getProps();
+
+    const entity = new UserEntity();
+    entity.id = user.id.unpack();
+    entity.name = props.name;
+    entity.profile = props.profile;
+    entity.email = props.email;
+    entity.emailActive = props.emailActive;
+
+    return entity;
+  }
+
+  static toDomain(entity: UserEntity): User {
+    return new User({
+      id: UUID.create(entity.id),
+      props: {
+        name: entity.name,
+        profile: entity.profile,
+        email: entity.email,
+        emailActive: entity.emailActive,
+      },
+    });
+  }
+}

--- a/src/user/test/domain/user.spec.ts
+++ b/src/user/test/domain/user.spec.ts
@@ -1,0 +1,84 @@
+import { UUID } from "src/common";
+import { User } from "../../domain";
+import copy from "fast-copy";
+
+describe("User", () => {
+  const validProps = {
+    name: "d_o0o_b",
+    email: "test@example.com",
+    profile: "https://example.com/image.png",
+  };
+
+  describe("create", () => {
+    it("정상적으로 인스턴스를 생성해야 한다", () => {
+      const user = User.create(validProps);
+      expect(user).toBeInstanceOf(User);
+      expect(user.getProps().name).toBe(validProps.name);
+      expect(user.getProps().email).toBe(validProps.email);
+      expect(user.getProps().profile).toBe(validProps.profile);
+    });
+  });
+
+  describe("validate", () => {
+    it("emailActive가 기본값 true로 설정된다", () => {
+      const user = User.create(validProps);
+      expect(user.getProps().emailActive).toBe(true);
+    });
+
+    it("emailActive를 false로 명시할 수 있다", () => {
+      const user = User.create({ ...validProps, emailActive: false });
+      expect(user.getProps().emailActive).toBe(false);
+    });
+
+    it("name이 없으면 예외가 발생한다", () => {
+      const p = copy(validProps);
+      p.name = "";
+      expect(() => User.create(p)).toThrow("Name 1 ~ 10 자 사이여야 합니다.");
+    });
+
+    it("name이 11자 이상이면 예외가 발생한다", () => {
+      const p = copy(validProps);
+      p.name = "a".repeat(11);
+      expect(() => User.create(p)).toThrow("Name 1 ~ 10 자 사이여야 합니다.");
+    });
+
+    it("이메일 길이가 256자 이상이면 예외가 발생한다", () => {
+      const p = copy(validProps);
+      p.email = "a".repeat(250) + "@x.com";
+      expect(() => User.create(p)).toThrow(
+        "Email은 1 ~ 255 자 사이의 유효한 이메일 형식이어야 합니다."
+      );
+    });
+
+    it("이메일 형식이 아니면 예외가 발생한다", () => {
+      const p = copy(validProps);
+      p.email = "invalid-email";
+      expect(() => User.create(p)).toThrow(
+        "Email은 1 ~ 255 자 사이의 유효한 이메일 형식이어야 합니다."
+      );
+    });
+
+    it("profile이 없으면 예외가 발생한다", () => {
+      const p = copy(validProps);
+      p.profile = "";
+      expect(() => User.create(p)).toThrow("Profile 존재하지 않습니다.");
+    });
+  });
+
+  describe("equals", () => {
+    it("같은 ID면 true를 반환해야 한다", () => {
+      const id = UUID.create();
+      const u1 = new User({ id, props: validProps });
+      const u2 = new User({ id, props: validProps });
+
+      expect(u1.equals(u2)).toBeTruthy();
+    });
+
+    it("다른 ID면 false를 반환해야 한다", () => {
+      const u1 = new User({ id: UUID.create(), props: validProps });
+      const u2 = new User({ id: UUID.create(), props: validProps });
+
+      expect(u1.equals(u2)).toBeFalsy();
+    });
+  });
+});

--- a/src/user/test/mappers/user.mapper.spec.ts
+++ b/src/user/test/mappers/user.mapper.spec.ts
@@ -1,0 +1,67 @@
+import { UserMapper } from "../../mappers";
+import { User } from "../../domain";
+import { User as UserEntity } from "src/database";
+
+const createValidUserDomain = (): User => {
+  return User.create({
+    name: "d_o0o_b",
+    email: "test@example.com",
+    profile: "https://example.com/image.png",
+    emailActive: false,
+  });
+};
+
+describe("UserMapper", () => {
+  describe("toPersistence", () => {
+    it("도메인 객체를 엔티티로 변환한다", () => {
+      const domain = createValidUserDomain();
+      const props = domain.getProps();
+
+      const entity = UserMapper.toPersistence(domain);
+
+      expect(entity).toBeInstanceOf(UserEntity);
+      expect(entity.id).toBe(domain.id.unpack());
+      expect(entity.name).toBe(props.name);
+      expect(entity.email).toBe(props.email);
+      expect(entity.profile).toBe(props.profile);
+      expect(entity.emailActive).toBe(props.emailActive);
+    });
+
+    it("emailActive가 undefined면 true로 설정된다", () => {
+      const domain = User.create({
+        name: "d_o0o_b",
+        email: "test@example.com",
+        profile: "https://example.com/image.png",
+        // emailActive 생략
+      });
+
+      const entity = UserMapper.toPersistence(domain);
+
+      expect(entity.emailActive).toBe(true);
+    });
+  });
+
+  describe("toDomain", () => {
+    it("엔티티를 도메인 객체로 변환한다", () => {
+      const domain = createValidUserDomain();
+      const props = domain.getProps();
+
+      const entity = new UserEntity();
+      entity.id = domain.id.unpack();
+      entity.name = props.name;
+      entity.email = props.email;
+      entity.profile = props.profile;
+      entity.emailActive = props.emailActive;
+
+      const result = UserMapper.toDomain(entity);
+      const resultProps = result.getProps();
+
+      expect(result).toBeInstanceOf(User);
+      expect(result.id.unpack()).toBe(entity.id);
+      expect(resultProps.name).toBe(entity.name);
+      expect(resultProps.email).toBe(entity.email);
+      expect(resultProps.profile).toBe(entity.profile);
+      expect(resultProps.emailActive).toBe(entity.emailActive);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -785,6 +785,11 @@
     path-to-regexp "3.2.0"
     tslib "2.5.3"
 
+"@nestjs/cqrs@^11.0.3":
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/@nestjs/cqrs/-/cqrs-11.0.3.tgz#aa6c482c12e883689955b07e3b8c4eb2b417d03d"
+  integrity sha512-2ezBftiXqVfNTzjCrmhazohYhIQzgm8rvM0aKndv73IOOBcVlNuNiQ3HHiHdd4c2w/3MOQDtsGbQHgZUuW6DPw==
+
 "@nestjs/jwt@^10.1.0":
   version "10.1.0"
   resolved "https://registry.npmjs.org/@nestjs/jwt/-/jwt-10.1.0.tgz"
@@ -2166,7 +2171,7 @@ combined-stream@^1.0.8:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@4.1.1:
+commander@4.1.1, commander@^4.0.0:
   version "4.1.1"
   resolved "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
@@ -2644,6 +2649,14 @@ entities@^4.2.0, entities@^4.4.0:
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
 
+env-cmd@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/env-cmd/-/env-cmd-10.1.0.tgz#c7f5d3b550c9519f137fdac4dd8fb6866a8c8c4b"
+  integrity sha512-mMdWTT9XKN7yNth/6N6g2GuKuJTsKMDHlQFUDacb/heQRRWOTIZ42t1rMHnQu4jYxU1ajdTeJM+9eEETlqToMA==
+  dependencies:
+    commander "^4.0.0"
+    cross-spawn "^7.0.0"
+
 error-ex@^1.3.1:
   version "1.3.2"
   resolved "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz"
@@ -2937,6 +2950,11 @@ extract-css@^3.0.0:
     href-content "^2.0.2"
     list-stylesheets "^2.0.1"
     style-data "^2.0.1"
+
+fast-copy@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/fast-copy/-/fast-copy-3.0.2.tgz#59c68f59ccbcac82050ba992e0d5c389097c9d35"
+  integrity sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -5072,7 +5090,7 @@ ms@2.1.2, ms@^2.1.1:
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@2.1.3:
+ms@2.1.3, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==


### PR DESCRIPTION
- [x] `uuid` 패키지 제거 → `crypto`(Node.js 내장 모듈) 대체
- [x] `fast-copy` 패키지 설치
- [x] 도메인 모델 추가 
  - `User`
  - `AuthSocial`
  - `RefreshToken`
  - `SocialCodeVO`
- [x] 사용자 인증 관련 유틸 추가
  - Mapper: `UserMapper`, `AuthSocialMapper`, `RefreshTokenMapper`
  - Guard: `ReissueTokenGuard`
  - Decorator: `@Social()`
  - Interface: `SocialPayload` 등..
- [x] Auth API
  - 카카오 소셜 로그인
  - 로그아웃
  - 회원 탈퇴
  - 토큰 재발급