### PR TITLE
auth, user module 수정

### DIFF
--- a/src/auth/commands/withdrawal/withdrawal.controller.ts
+++ b/src/auth/commands/withdrawal/withdrawal.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, UseGuards } from "@nestjs/common";
+import { Controller, Delete, UseGuards } from "@nestjs/common";
 import { CommandBus } from "@nestjs/cqrs";
 import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { AccessTokenGuard, SwaggerAuth, User, UserPayload } from "src/common";
@@ -9,7 +9,7 @@ import { WithdrawalCommand } from "./withdrawal.command";
 export class WithdrawalController {
   constructor(private readonly commandBus: CommandBus) {}
 
-  @Post("withdrawal")
+  @Delete("withdrawal")
   @UseGuards(AccessTokenGuard)
   @ApiOperation({ summary: "회원탈퇴" })
   @ApiBearerAuth(SwaggerAuth.AUTH_AT)

--- a/src/user/commands/update-info/update-info.handler.ts
+++ b/src/user/commands/update-info/update-info.handler.ts
@@ -29,10 +29,19 @@ export class UpdateInfoCommandHandler
     const user = UserMapper.toDomain(findUser);
     user.updateInfo({ name, email, emailActive });
 
-    const result = await this.manager.save(
+    const updateResult = await this.manager.update(
       User,
+      userId,
       UserMapper.toPersistence(user)
     );
+
+    if (!updateResult.affected) {
+      throw new Error("User update failed");
+    }
+
+    const result = await this.manager.findOne(User, {
+      where: { id: userId },
+    });
 
     return {
       userId: result.id,


### PR DESCRIPTION
- [x] 회원 탈퇴 API `POST` -> `DELETE`로 변경
- [x] 사용자 정보 업데이트 실패 시 예외 처리 추가